### PR TITLE
Make retrieval off ACLs optional in statObject / Add HTTP response code validation for retrieveACLs method.

### DIFF
--- a/lib/src/minio.dart
+++ b/lib/src/minio.dart
@@ -1086,6 +1086,8 @@ class Minio {
       queries: {'acl': ''},
     );
 
+    validate(resp, expect: 200);
+
     return AccessControlPolicy.fromXml(
       xml.XmlDocument.parse(resp.body)
           .findElements('AccessControlPolicy')

--- a/lib/src/minio.dart
+++ b/lib/src/minio.dart
@@ -1096,7 +1096,8 @@ class Minio {
   }
 
   /// Stat information of the object.
-  Future<StatObjectResult> statObject(String bucket, String object) async {
+  Future<StatObjectResult> statObject(String bucket, String object,
+      {bool retrieveACLs = true}) async {
     MinioInvalidBucketNameError.check(bucket);
     MinioInvalidObjectNameError.check(object);
 
@@ -1118,7 +1119,7 @@ class Minio {
       size: int.parse(resp.headers['content-length']!),
       metaData: extractMetadata(resp.headers),
       lastModified: parseRfc7231Time(resp.headers['last-modified']!),
-      acl: await getObjectACL(bucket, object),
+      acl: retrieveACLs ? await getObjectACL(bucket, object) : null,
     );
   }
 }


### PR DESCRIPTION
I have been experiencing issues with retrieving the stats for an object.
With Cloud Object Storage in IBM Cloud the ACLs can only be retrieved with _Manager_ permissions which is more than _Reader_ / _Writer_.
In my use case I do not need the ACL information but I do need the content-type that can be retrived by _statObject_ method.

This change adds an optional (named) parameter that allows to skip retrieval of the ACLs.

I also noticed that when the query for the ACL fails with HTTP responce code 403 (as it did in my use case) the code will not notice and will try to parse the XML that is expected to be returned and will of course fail. So I added a validation call like in the other methods.